### PR TITLE
Display any error returned by main in a nicer way

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "dirstat-rs"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty-bytes 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dirstat-rs"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["scullionw <scuw1801@usherbrooke.ca>"]
 edition = "2018"
 license = "MIT"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -20,7 +20,21 @@ mod shape {
     pub const SPACING: &str = "──";
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() {
+    if let Err(e) = dirstat() {
+        let bufwtr = BufferWriter::stderr(ColorChoice::Always);
+        let mut buffer = bufwtr.buffer();
+        buffer
+            .set_color(ColorSpec::new().set_fg(Some(Color::Red)))
+            .unwrap();
+        writeln!(&mut buffer, "Error: {}", e).unwrap();
+        bufwtr.print(&buffer).unwrap();
+
+        std::process::exit(1);
+    }
+}
+
+fn dirstat() -> Result<(), Box<dyn Error>> {
     let config = Config::from_args();
     let current_dir = env::current_dir()?;
     let target_dir = config.target_dir.as_ref().unwrap_or(&current_dir);


### PR DESCRIPTION
Previously, returning an error from main prints out the rust representation of the error struct:
![image](https://user-images.githubusercontent.com/8473174/103835707-facac600-5054-11eb-86e4-210b3c536909.png)

This PR moves the existing main into it's own function so the real main can handle errors nicely:
![image](https://user-images.githubusercontent.com/8473174/103835667-e4bd0580-5054-11eb-8559-e4eafe502e62.png)
