### PR TITLE
Fix bug: high word of size for compressed files on windows was ignored

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dirstat-rs"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["scullionw <scuw1801@usherbrooke.ca>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
![bugreport-ds](https://user-images.githubusercontent.com/775038/139158694-0280f4d6-1803-47d1-9d2e-b38ba8e57d33.png)

There was a null pointer passing in all the time. This signaled to function that we "don't want" high word.

In C (or in win API at least) it's a common pattern to accept pointers for optional arguments.

Notice, if you would work with such APIs in future.

In case when we need to check pointers for zero, like was in the original code: then the function would accept double pointer ( `void**`). Then we have a local variable defined as a regular pointer and an argument defined as a double-pointer. Then library could write something into our pointer. 

**P.S.** I'm not sure if I should bump version instead of a maintainer, but made it just in case.