### PR TITLE
Fix spelling and expanded cmd switch description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "dirstat-rs"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "atty",
  "pretty-bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dirstat-rs"
-version = "0.3.7"
+version = "0.3.8"
 authors = ["scullionw <scuw1801@usherbrooke.ca>"]
 edition = "2018"
 license = "MIT"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut buffer = stdout.buffer();
 
     if !config.json {
-        println!("\nAnalysing: {}\n", target_dir.display())
+        println!("\nAnalyzing: {}\n", target_dir.display())
     };
 
     let analysed = match file_info {
@@ -187,6 +187,8 @@ struct Config {
 
     #[structopt(short = "a")]
     /// Apparent size on disk.
+    ///
+    /// This would actually retrieve allocation size of files (AKA physical size on disk)
     apparent: bool,
 
     #[structopt(short = "j")]


### PR DESCRIPTION
Fix spelling and added better description to one of command line switches